### PR TITLE
🤖 Don't attempt to assign Dependabot

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -18,7 +18,7 @@ const run = async () => {
     const assignees = pr.assignees
     const author = pr.user
 
-    if (!assignees || assignees.length === 0) {
+    if ((!assignees || assignees.length === 0) && author.login !== "dependabot[bot]") {
       await client.request(`POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`, {
         owner,
         repo,


### PR DESCRIPTION
Dependabot is just a bot and can't be assigned to a PR. When he opens a PR, this action throws [an error]:

```
Resource not accessible by integration
```

Let's just skip the whole thing in this case.

[an error]: https://github.com/planningcenter/people/actions/runs/3422605052/jobs/5700206658