### PR TITLE
Use balto-utils NCC workflow to build dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: build
+on:
+  push:
+    # Can't push a build commit to a tag, so only run for branches
+    branches:
+      - '**'
+    paths:
+      # Include any files that could require rebuilding
+      - 'package-lock.json'
+      - 'src/**'
+
+jobs:
+  ncc-build:
+    uses: planningcenter/balto-utils/.github/workflows/ncc.yml@v2


### PR DESCRIPTION
Building the distribution file that's actually used when this workflow is referenced has been manual until now (and the current release's dist/ is out of sync with src/). But balto-utils has a workflow we can use to automate that. Using the default setup for that workflow and hopefully it works!