### PR TITLE
chore(Releases): Update update-action-tags.yml

### DIFF
--- a/.github/workflows/update-action-tags.yml
+++ b/.github/workflows/update-action-tags.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v([0-9]+)\.([0-9]+)\.([0-9]+)'
+  release:
+    types:
+      - published
+      - edited
 
 jobs:
   update-action-tags:


### PR DESCRIPTION
## Why this was needed
We want semver updates to happen when we make a new release. Apparently making the tag during the release process doesn't trigger the `push tags` event like we though.

## How I fixed it
Copied the "simple setup" from the readme
https://github.com/tchupp/actions-update-semver-tags/tree/main?tab=readme-ov-file#simple-setup