### PR TITLE
chore: address deprecation warnings and attempt to address flaky Dependabot behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a GitHub action that assigns a PR owner upon opening a pull request.
 Sample config, place in `.github/workflows/assign.yml`
 
 ```
-name: Pull assign
+name: Pull Assign
 
 on:
   pull_request:

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: "node16"
+  using: node20
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -9687,38 +9687,41 @@ var __webpack_exports__ = {};
 const core = __nccwpck_require__(2186)
 const github = __nccwpck_require__(5438)
 
-const run = async () => {
-  try {
-    const githubToken = core.getInput('github_token')
+async function run() {
+  const githubToken = core.getInput('github_token')
 
-    if (!githubToken) throw Error(`input 'github_token' is required`)
+  if (!githubToken) throw Error(`input 'github_token' is required`)
 
-    const client = github.getOctokit(githubToken)
-    const owner = github.context.payload.repository.owner.login
-    const repo = github.context.payload.repository.name
-    const issue_number = github.context.payload.pull_request.number
+  const client = github.getOctokit(githubToken)
+  const owner = github.context.payload.repository.owner.login
+  const repo = github.context.payload.repository.name
+  const issue_number = github.context.payload.pull_request.number
 
-    const pr = github.context.payload.pull_request
-    const assignees = pr.assignees
-    const author = pr.user
+  const pr = github.context.payload.pull_request
+  const assignees = pr.assignees
+  const author = pr.user
 
-    if (
-      (!assignees || assignees.length === 0) &&
-      author.login !== 'dependabot[bot]'
-    ) {
-      await client.request(
-        `POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`,
-        { owner, repo, issue_number, assignees: [author.login] }
-      )
-    }
-  } catch (error) {
-    console.log('Error:', error)
-    core.error(error)
-    core.setFailed(error)
+  console.log(`assignees: ${JSON.stringify(assignees, undefined, 2)}`)
+  console.log(`author: ${JSON.stringify(author, undefined, 2)}`)
+
+  if (
+    (!assignees || assignees.length === 0) &&
+    (author.is_bot === false || (author.type && author.type !== 'Bot'))
+  ) {
+    await client.request(
+      `POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`,
+      { owner, repo, issue_number, assignees: [author.login] }
+    )
   }
 }
 
-run()
+try {
+  run()
+} catch (error) {
+  console.log('Error:', error)
+  core.error(error)
+  core.setFailed(error.message)
+}
 
 })();
 

--- a/src/action.js
+++ b/src/action.js
@@ -1,37 +1,37 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
 
-const run = async () => {
-  try {
-    const githubToken = core.getInput('github_token')
+async function run() {
+  const githubToken = core.getInput('github_token')
 
-    if (!githubToken) throw Error(`input 'github_token' is required`)
+  if (!githubToken) throw Error(`input 'github_token' is required`)
 
-    const client = github.getOctokit(githubToken)
-    const owner = github.context.payload.repository.owner.login
-    const repo = github.context.payload.repository.name
-    const issue_number = github.context.payload.pull_request.number
+  const client = github.getOctokit(githubToken)
+  const owner = github.context.payload.repository.owner.login
+  const repo = github.context.payload.repository.name
+  const issue_number = github.context.payload.pull_request.number
 
-    const pr = github.context.payload.pull_request
-    const assignees = pr.assignees
-    const author = pr.user
+  const pr = github.context.payload.pull_request
+  const assignees = pr.assignees
+  const author = pr.user
 
-    console.log(`pr: ${JSON.stringify(pr, undefined, 2)}`)
+  console.log(`pr: ${JSON.stringify(pr, undefined, 2)}`)
 
-    if (
-      (!assignees || assignees.length === 0) &&
-      !author.is_bot
-    ) {
-      await client.request(
-        `POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`,
-        { owner, repo, issue_number, assignees: [author.login] }
-      )
-    }
-  } catch (error) {
-    console.log('Error:', error)
-    core.error(error)
-    core.setFailed(error)
+  if (
+    (!assignees || assignees.length === 0) &&
+    !author.is_bot
+  ) {
+    await client.request(
+      `POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`,
+      { owner, repo, issue_number, assignees: [author.login] }
+    )
   }
 }
 
-run()
+try {
+  run()
+} catch (error) {
+  console.log('Error:', error)
+  core.error(error)
+  core.setFailed(error.message)
+}

--- a/src/action.js
+++ b/src/action.js
@@ -15,7 +15,8 @@ async function run() {
   const assignees = pr.assignees
   const author = pr.user
 
-  console.log(`pr: ${JSON.stringify(pr, undefined, 2)}`)
+  console.log(`assignees: ${JSON.stringify(assignees, undefined, 2)}`)
+  console.log(`author: ${JSON.stringify(author, undefined, 2)}`)
 
   if (
     (!assignees || assignees.length === 0) &&

--- a/src/action.js
+++ b/src/action.js
@@ -20,7 +20,7 @@ const run = async () => {
 
     if (
       (!assignees || assignees.length === 0) &&
-      author.login !== 'dependabot[bot]'
+      !author.is_bot
     ) {
       await client.request(
         `POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`,

--- a/src/action.js
+++ b/src/action.js
@@ -16,6 +16,8 @@ const run = async () => {
     const assignees = pr.assignees
     const author = pr.user
 
+    console.log(`pr: ${JSON.stringify(pr, undefined, 2)}`)
+
     if (
       (!assignees || assignees.length === 0) &&
       author.login !== 'dependabot[bot]'

--- a/src/action.js
+++ b/src/action.js
@@ -19,7 +19,7 @@ async function run() {
 
   if (
     (!assignees || assignees.length === 0) &&
-    !author.is_bot
+    (author.is_bot === false || (author.type && author.type !== 'Bot'))
   ) {
     await client.request(
       `POST /repos/${owner}/${repo}/issues/${issue_number}/assignees`,


### PR DESCRIPTION
I started by looking into why Dependabot PRs sometimes fail with this action. 

Then, that slowly morphed into some light refactoring. By walking through each commit separately, you can see the important changes of the `node` deprecation and how we now check if a Bot made the PR being run against in two different ways.